### PR TITLE
Add missing configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [tool.black]
 line-length = 110
 target-version = ["py39"]
+
+[tool.poetry]
+name = "docker-vim"
+version = "0.0.0"
+description = "Docker image with vim and other tools."
+authors = ["Stéphane Brunner <stephane.brunner@gmail.com>"]


### PR DESCRIPTION
Needed to make `poetry --version` work, used in the audit.